### PR TITLE
Pass the original filename to VM for clearer stack traces

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@
                             module: sandboxModule,
                             exports: sandboxModule.exports
                         };
-                    vm.runInNewContext(script, extend({require:require}, global, sandbox));
+                    vm.runInNewContext(script, extend({require:require}, global, sandbox), { filename: path.basename(module) });
                     return sandbox.module.exports;
                 });
     }

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@
                             module: sandboxModule,
                             exports: sandboxModule.exports
                         };
-                    vm.runInNewContext(script, extend({require:require}, global, sandbox), { filename: path.basename(module) });
+                    vm.runInNewContext(script, extend({require:require}, global, sandbox), { filename: path.basename(moduleId) });
                     return sandbox.module.exports;
                 });
     }


### PR DESCRIPTION
Before:
```javascript
evalmachine.<anonymous>:3
		undef.alert();
		^

ReferenceError: undef is not defined
    at module.exports.default (evalmachine.<anonymous>:3:3)
    at Object.<anonymous> (.../test-vm/test-vm.js:46:1)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Function.Module.runMain (module.js:676:10)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:608:3
```

After:
```javascript
some-required-module.js:3
		undef.alert();
		^

ReferenceError: undef is not defined
    at module.exports.default (some-required-module.js:3:3)
    at Object.<anonymous> (.../test-vm/test-vm.js:46:1)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Function.Module.runMain (module.js:676:10)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:608:3
```

Notice: `evalmachine.<anonymous>:3:3` vs `some-required-module.js:3:3`